### PR TITLE
docs: align documentation with current GitOps state

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 ### 🔧 運用ガイド
 - [運用ガイド](operations-guide.md) - 日常運用とメンテナンス
 - [トラブルシューティング](troubleshooting.md) - 問題解決ガイド
+- [外部公開ガイド](external-access-guide.md) - Cloudflared/Gateway/TLS 運用手順
 
 ### 🚀 アプリケーション
 - [アプリケーション管理](applications.md) - デプロイされているアプリケーション

--- a/docs/diagrams/app-of-apps-sync-wave.md
+++ b/docs/diagrams/app-of-apps-sync-wave.md
@@ -80,6 +80,8 @@ flowchart TD
 
   subgraph user_definitions["User App Definitions (wave 11)"]
     uad_argocd["argocd-external"]:::wave11
+    uad_blog["blog"]:::wave11
+    uad_cooklog["cooklog"]:::wave11
     uad_rustfs["rustfs"]:::wave11
     uad_rustfs_ext["rustfs-external"]:::wave11
     uad_cloudflared["cloudflared"]:::wave11
@@ -92,6 +94,8 @@ flowchart TD
 
   subgraph user_applications["User Applications (wave 12)"]
     ua_argocd["argocd"]:::wave12
+    ua_blog["blog"]:::wave12
+    ua_cooklog["cooklog"]:::wave12
     ua_rustfs["rustfs"]:::wave12
     ua_cloudflared["cloudflared"]:::wave12
     ua_hitomi["hitomi"]:::wave12

--- a/docs/gitops-design.md
+++ b/docs/gitops-design.md
@@ -12,44 +12,24 @@ k8s_myHomeプロジェクトは、ArgoCDを使用したGitOpsパターンを採�
 
 - `docs/diagrams/app-of-apps-sync-wave.md`
 
-```
-┌─────────────────────────────────────────────────┐
-│              Root Application                    │
-│   (bootstrap/app-of-apps.yaml)                  │
-└──────────────┬──────────────────────────────────┘
-               │
-    ┌──────────┴───────────┬──────────┬──────────┐
-    │                      │          │          │
-┌───▼────┐         ┌──────▼────┐ ┌──▼──┐  ┌────▼────┐
-│ Core   │         │Platform   │ │Infra│  │  Apps   │
-│ Apps   │         │Services   │ │     │  │         │
-└────────┘         └───────────┘ └─────┘  └─────────┘
-    │                   │           │          │
-    ├─ namespaces      ├─ ArgoCD   ├─ MetalLB ├─ Slack
-    ├─ storage-class   ├─ Harbor   ├─ NGINX Gateway   ├─ RSS
-    └─ rbac            └─ ESO      └─ Cert    └─ Hitomi
-```
-
 ### デプロイメント Wave
 
 ArgoCDのSync Wavesを使用して、依存関係を考慮した順序でデプロイ：
 
 | Wave | コンポーネント | 説明 |
 |------|-------------|------|
+| 0 | ArgoCD Projects | AppProjectを先行作成 |
 | 1 | Local Path Provisioner | ストレージプロビジョナー |
-| 2 | Core (Namespaces) | 基本リソース |
+| 2 | Core / CoreDNS Config | 基本リソースとDNS固定設定 |
 | 3 | MetalLB | LoadBalancer |
 | 4 | MetalLB Config | IPプール設定 |
 | 5 | Gateway API CRD | Gateway APIリソース |
 | 6 | NGINX Gateway Fabric | Gatewayコントローラー |
-| 7 | cert-manager | 証明書管理 |
-| 7 | cert-manager Config | Issuer設定 |
-| 7 | External Secrets | シークレット管理 |
+| 7 | cert-manager / cert-manager Config / External Secrets Operator | 証明書・Secret管理 |
 | 8 | Gateway Resources | Gateway/共通設定 |
 | 9 | Config Secrets | 外部連携用ExternalSecret |
-| 10 | Platform Services | ArgoCD, Harbor |
-| 11 | Monitoring | Grafana k8s-monitoring |
-| 11 | User App Definitions | アプリケーション定義 |
+| 10 | Platform / ArgoCD Image Updater / Harbor / Tailscale Operator | 基盤サービス |
+| 11 | Monitoring / User App Definitions / Tailscale Connector | 監視・アプリ定義・接続基盤 |
 | 12 | User Applications | 実際のアプリケーション |
 | 13 | Harbor Patches | Harbor後処理 |
 
@@ -59,16 +39,19 @@ ArgoCDのSync Wavesを使用して、依存関係を考慮した順序でデプ�
 manifests/
 ├── bootstrap/
 │   └── app-of-apps.yaml         # ルートApplication
-├── config/
-│   └── secrets/                 # 外部連携用シークレット
 ├── core/
-│   ├── namespaces/              # Namespace定義
-│   └── storage-classes/         # StorageClass定義
+│   ├── namespaces.yaml          # Namespace定義
+│   └── networkpolicies.yaml     # 基本NetworkPolicy
 ├── infrastructure/
 │   ├── networking/
-│   │   └── metallb/             # MetalLB設定
+│   │   ├── coredns/             # CoreDNS固定エントリ
+│   │   ├── metallb/             # MetalLB設定
+│   │   ├── nginx-gateway-fabric/
+│   │   └── tailscale-operator/
 │   ├── security/
 │   │   └── cert-manager/        # 証明書管理
+│   ├── storage/
+│   │   └── local-path/          # Local Path Provisioner
 │   └── gitops/
 │       └── harbor/              # Harborパッチ
 ├── monitoring/
@@ -80,8 +63,13 @@ manifests/
 │   └── secrets/
 │       └── external-secrets/    # ESO設定
 └── apps/
-    ├── cloudflared/             # アプリケーション
+    ├── argocd/
+    ├── blog/
+    ├── cloudflared/
+    ├── cooklog/
     ├── hitomi/
+    ├── rustfs/
+    ├── selenium/
     └── slack/
 ```
 
@@ -119,19 +107,19 @@ AppProject は `argocd-projects` Application で先行適用します。
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: example-app
+  name: <app-name>
   namespace: argocd
   annotations:
-    argocd.argoproj.io/sync-wave: "10"  # デプロイ順序
+    argocd.argoproj.io/sync-wave: "12"  # user-applications に合わせる
 spec:
-  project: default
+  project: apps
   source:
     repoURL: https://github.com/ksera524/k8s_myHome.git
-    targetRevision: main
-    path: manifests/apps/example
+    targetRevision: HEAD
+    path: manifests/apps/<app-name>
   destination:
     server: https://kubernetes.default.svc
-    namespace: example
+    namespace: <namespace>
   syncPolicy:
     automated:
       prune: true        # 削除されたリソースを自動削除
@@ -297,13 +285,11 @@ jobs:
       
       - name: Update Manifest
         run: |
-          sed -i "s|image:.*|image: harbor.qroksera.com/sandbox/${{ github.repository }}:${{ github.sha }}|" manifests/apps/myapp/deployment.yaml
+          sed -i "s|image:.*|image: harbor.qroksera.com/sandbox/${{ github.repository }}:${{ github.sha }}|" manifests/apps/<app-name>/manifest.yaml
           
       - name: Commit and Push
         run: |
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
-          git add manifests/apps/myapp/deployment.yaml
+          git add manifests/apps/<app-name>/manifest.yaml
           git commit -m "Update image to ${{ github.sha }}"
           git push
 ```
@@ -315,9 +301,9 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   annotations:
-    argocd-image-updater.argoproj.io/image-list: myapp=harbor.qroksera.com/sandbox/myapp
-    argocd-image-updater.argoproj.io/myapp.update-strategy: latest
-    argocd-image-updater.argoproj.io/myapp.pull-secret: pullsecret:arc-systems/harbor-registry-secret
+    argocd-image-updater.argoproj.io/image-list: app=harbor.qroksera.com/sandbox/<app-name>
+    argocd-image-updater.argoproj.io/app.update-strategy: semver
+    argocd-image-updater.argoproj.io/app.pull-secret: pullsecret:argocd/harbor-registry
 ```
 
 ## モニタリングと可観測性

--- a/docs/kubernetes-architecture.md
+++ b/docs/kubernetes-architecture.md
@@ -86,7 +86,7 @@ k8s_myHomeは、QEMU/KVM仮想化基盤上に構築された本格的な3ノー�
 ### 3. GitOps
 
 #### ArgoCD
-- **バージョン**: 5.51.6
+- **デプロイ方式**: upstream `install.yaml`（stable追従）
 - **パターン**: App-of-Apps
 - **認証**: GitHub OAuth統合
 - **同期間隔**: 3分（デフォルト）
@@ -99,8 +99,11 @@ k8s_myHomeは、QEMU/KVM仮想化基盤上に構築された本格的な3ノー�
   - 内部: harbor.internal.qroksera.com (192.168.122.100)
   - 外部: harbor.qroksera.com (Cloudflare経由)
 - **ストレージ**:
-  - Registry: 100Gi
-  - Database: 10Gi
+  - Registry: 10Gi
+  - JobService Log: 1Gi
+  - Database: 1Gi
+  - Redis: 1Gi
+  - Trivy: 5Gi
 - **認証**: admin/<harbor-admin-password>（初期値は変更）
 
 ### 5. CI/CD
@@ -108,7 +111,7 @@ k8s_myHomeは、QEMU/KVM仮想化基盤上に構築された本格的な3ノー�
 #### GitHub Actions Runner Controller (ARC)
 - **タイプ**: Runner ScaleSet
 - **設定**: 
-  - minRunners: 0-1（設定可能）
+  - minRunners: 1（推奨、設定可能）
   - maxRunners: 3（デフォルト）
 - **モード**: Docker-in-Docker (dind)
 

--- a/docs/manifest-layout.md
+++ b/docs/manifest-layout.md
@@ -10,12 +10,12 @@
 - `platform/`: GitOps運用基盤・CI/CD・Secrets運用（ArgoCD設定、ESO、ARC等）
 - `monitoring/`: 監視関連の manifests/values
 - `apps/`: ユーザーアプリの実マニフェスト
-- `config/`: 非Secretの外部連携設定のみ
 
 ## ArgoCD Application 定義
 
-- App-of-Apps は `bootstrap/` にのみ配置
-- それ以外の Application 定義は `bootstrap/applications/` に集約
+- Root App-of-Apps は `bootstrap/app-of-apps.yaml` に配置
+- ユーザーアプリ向け Application 定義は `bootstrap/applications/user-apps/` に配置
+- 基盤コンポーネント向け Application は `bootstrap/app-of-apps.yaml` から参照
 - `core/` 以下に Application 定義を置かない
 
 ## cert-manager 関連
@@ -26,7 +26,6 @@
 ## ExternalSecrets
 
 - ESO 本体と ExternalSecret 定義は `platform/secrets/external-secrets/` に集約
-- `config/` には ExternalSecret を置かない（非Secretの外部連携設定のみ）
 
 ## monitoring
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -432,9 +432,8 @@ kubectl get ns -A -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata
 # イメージスキャン（Harborで自動実行）
 # Harbor UIでスキャン結果確認
 
-# Pod Security Policy確認
-kubectl get psp
-kubectl describe psp <policy-name>
+# Namespace の PSA ラベル確認
+kubectl get ns -A -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.metadata.labels.pod-security\.kubernetes\.io/enforce}{"\n"}{end}'
 ```
 
 #### RBAC管理

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,561 +2,214 @@
 
 ## 概要
 
-k8s_myHomeで発生する可能性のある問題と、その解決方法について説明します。
+このガイドは、k8s_myHome の現行構成（App-of-Apps + GitOps）で発生しやすい問題の切り分け手順をまとめたものです。
 
 ## このガイドの範囲
 
-- 対象: 障害時の一次切り分け、ログ/イベント確認、代表的な復旧手順
-- 非対象: 日常運用は `docs/operations-guide.md`、初期構築は `docs/setup-guide.md`、バージョンアップは `docs/kubernetes-upgrade-guide.md`
+- 対象: 障害時の一次切り分け、主要コンポーネントの復旧、ログ収集
+- 非対象: 日常運用は `docs/operations-guide.md`、初期構築は `docs/setup-guide.md`、アップグレードは `docs/kubernetes-upgrade-guide.md`
 
-## 一般的な診断コマンド
+## まず最初に実行する確認
 
 ```bash
-# 確認フェーズ
+# 検証フェーズ
 make phase5
 
-# 詳細な状態確認
-kubectl get nodes -o wide
-kubectl get applications -n argocd
-kubectl get pods -A | grep -v Running | head -20
-
-# ログ確認
+# 実行ログ
 cat automation/run.log
 ```
 
-## セットアップ時の問題
-
-### 1. make all が失敗する
-
-#### 症状
-```
-ERROR: make all failed
-```
-
-#### 原因と解決方法
-
-**権限不足**
-```bash
-# sudo権限確認
-sudo -v
-
-# libvirtグループ確認
-groups | grep libvirt
-
-# グループに追加（必要な場合）
-sudo usermod -aG libvirt $USER
-# ログアウト・ログイン必要
-```
-
-**ディスク容量不足**
-```bash
-# 容量確認
-df -h
-
-# 必要容量: 200GB以上
-# 不要なファイル削除
-sudo apt clean
-docker system prune -a
-```
-
-**ネットワーク問題**
-```bash
-# DNS確認
-nslookup google.com
-
-# プロキシ設定（必要な場合）
-export HTTP_PROXY=http://proxy.example.com:8080
-export HTTPS_PROXY=http://proxy.example.com:8080
-```
-
-#### ログ確認
-```bash
-cat automation/run.log
-```
-
-### 2. VM が起動しない
-
-#### 症状
-```
-Failed to start domain k8s-control-plane
-```
-
-#### 解決方法
+Control Plane 上で直接確認する場合:
 
 ```bash
-# libvirtサービス確認
-sudo systemctl status libvirtd
-sudo systemctl restart libvirtd
-
-# ネットワーク確認
-sudo virsh net-list --all
-sudo virsh net-start default
-
-# VM強制削除と再作成
-cd automation/infrastructure
-terraform destroy -auto-approve
-terraform apply -auto-approve
-```
-
-### 3. Terraform エラー
-
-#### 症状
-```
-Error: Error acquiring the state lock
-```
-
-#### 解決方法
-
-```bash
-# ロック解除
-cd automation/infrastructure
-rm -f .terraform.lock.hcl
-terraform force-unlock <lock-id>
-
-# 状態ファイルリセット
-rm -f terraform.tfstate*
-terraform init
-```
-
-## Kubernetes クラスター問題
-
-### 1. ノードが NotReady
-
-#### 症状
-```
-NAME                STATUS     ROLES
-k8s-control-plane   NotReady   control-plane
-```
-
-#### 診断と解決
-
-```bash
-# ノード詳細確認
-kubectl describe node k8s-control-plane
-
-# kubelet状態確認
 ssh k8suser@192.168.122.10
-sudo systemctl status kubelet
-sudo journalctl -u kubelet -n 100
-
-# 一般的な修正
-sudo systemctl restart kubelet
-sudo systemctl restart containerd
+kubectl get nodes
+kubectl get applications -n argocd
+kubectl get pods -A
 ```
 
-### 2. Pod が Pending/CrashLoopBackOff
+## 典型障害と対処
 
-#### Pending状態
+### 1. `make all` / `make phaseX` が失敗する
 
 ```bash
-# Pod詳細確認
+# 直近エラーの確認
+cat automation/run.log
+
+# 必須ツール確認
+command -v shellcheck
+command -v yamllint
+command -v kustomize
+
+# CI相当チェック
+automation/scripts/ci/validate.sh
+```
+
+確認ポイント:
+
+- `automation/settings.toml` の必須項目が未設定
+- Pulumi / GitHub 認証情報の不足
+- ホスト側のディスク容量不足
+
+### 2. ノードが `NotReady`
+
+```bash
+kubectl get nodes -o wide
+kubectl describe node <node-name>
+
+ssh k8suser@<node-ip> 'sudo systemctl status kubelet'
+ssh k8suser@<node-ip> 'sudo journalctl -u kubelet -n 200'
+```
+
+復旧の第一手:
+
+```bash
+ssh k8suser@<node-ip> 'sudo systemctl restart containerd && sudo systemctl restart kubelet'
+```
+
+### 3. Pod が `Pending` / `CrashLoopBackOff`
+
+```bash
+kubectl get pods -n <namespace>
 kubectl describe pod <pod-name> -n <namespace>
-
-# よくある原因：
-# 1. リソース不足
-kubectl top nodes
-kubectl describe node | grep -A 5 "Allocated resources"
-
-# 2. PVC未作成
-kubectl get pvc -n <namespace>
-
-# 3. イメージプル失敗
-kubectl get events -n <namespace>
-```
-
-#### CrashLoopBackOff
-
-```bash
-# ログ確認
 kubectl logs <pod-name> -n <namespace>
 kubectl logs <pod-name> -n <namespace> --previous
-
-# 起動コマンド確認
-kubectl get pod <pod-name> -n <namespace> -o yaml | grep -A 10 command
-
-# 一時的なデバッグPod起動
-kubectl run -it debug --image=<same-image> --restart=Never -- /bin/sh
+kubectl get events -n <namespace> --sort-by='.lastTimestamp'
 ```
 
-### 3. Service に接続できない
+切り分け観点:
 
-#### 症状
-```
-curl: (7) Failed to connect to service
-```
+- ImagePull エラー（レジストリ認証、タグ不整合）
+- PVC 未バインド（StorageClass/PV不足）
+- Secret/ConfigMap 不足
 
-#### 診断
+### 4. ArgoCD が `OutOfSync` / `Degraded`
 
 ```bash
-# Service確認
-kubectl get svc -n <namespace>
-kubectl get endpoints -n <namespace>
-
-# Pod selector確認
-kubectl get svc <service-name> -n <namespace> -o yaml | grep selector -A 5
-kubectl get pods -n <namespace> --show-labels
-
-# DNS確認
-kubectl run -it --rm debug --image=alpine --restart=Never -- nslookup <service>.<namespace>
-```
-
-## ArgoCD 問題
-
-### 1. Application が OutOfSync
-
-#### 症状
-```
-SYNC STATUS: OutOfSync
-```
-
-#### 解決方法
-
-```bash
-# 差分確認
+kubectl get applications -n argocd
+kubectl describe application <app-name> -n argocd
 kubectl get application <app-name> -n argocd -o jsonpath='{.status}'
 
-# 手動同期
+# ハードリフレッシュ
 kubectl patch application <app-name> -n argocd \
   --type merge -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}'
-
-# 強制同期
-argocd app sync <app-name> --force --prune
 ```
 
-### 2. ArgoCD UIにアクセスできない
+`OutOfSync` が続く場合:
+
+- マニフェストが複数経路で apply されていないか
+- CRD/Webhook など順序依存リソースの Sync Wave を誤っていないか
+
+### 5. ExternalSecret が同期されない
 
 ```bash
-# Port Forward再起動
-pkill -f "port-forward.*argocd"
-kubectl port-forward svc/argocd-server -n argocd 8080:443
-
-# Service確認
-kubectl get svc -n argocd
-kubectl logs -n argocd deployment/argocd-server
-```
-
-## Harbor 問題
-
-### 1. イメージプッシュ失敗
-
-#### 症状
-```
-unauthorized: unauthorized to access repository
-```
-
-#### 解決方法
-
-```bash
-# ログイン（内部）
-docker login harbor.internal.qroksera.com
-# Username: admin
-# Password: <harbor-admin-password>（初期値は変更）
-
-# hosts ファイル確認
-grep harbor.internal.qroksera.com /etc/hosts
-# なければ追加
-echo "192.168.122.100 harbor.internal.qroksera.com" | sudo tee -a /etc/hosts
-
-# 内部CAを端末に信頼させる
-# (k8s-myhome-internal-ca を OS の信頼ストアへ追加)
-
-# GitHub Actions Runner で TLS エラーが出る場合
-# add-runner.sh で Runner(dind) に内部CAを配布するため、再作成する
-# make add-runner REPO=your-repo
-
-# レジストリSecret再作成
-kubectl delete secret harbor-registry-secret -n <namespace>
-kubectl create secret docker-registry harbor-registry-secret \
-  --docker-server=harbor.internal.qroksera.com \
-  --docker-username=admin \
-  --docker-password=<harbor-admin-password> \
-  -n <namespace>
-```
-
-### 2. Harbor UIアクセス不可
-
-```bash
-# Pod状態確認
-kubectl get pods -n harbor
-
-# Core コンポーネント再起動
-kubectl rollout restart deployment/harbor-core -n harbor
-
-# データベース確認
-kubectl logs -n harbor statefulset/harbor-database
-```
-
-## 外部公開/TLS 問題
-
-### 1. Let’s Encrypt 429（rate limit）
-
-#### 症状
-```
-Order が errored / rateLimited
-```
-
-#### 原因と解決方法
-
-- 同一FQDNセットで 7 日間に 5 回までの制限に到達している
-- 対策:
-  - ワイルドカード証明書（`*.qroksera.com`）を 1 枚運用に統一
-  - 検証時は staging Issuer を使い、本番は解除後に切り替える
-
-```bash
-kubectl get order -A
-kubectl describe order <name> -n <namespace>
-```
-
-### 2. Cloudflare で 502 Bad Gateway
-
-#### 症状
-```
-curl -I https://<app>.qroksera.com
-HTTP/2 502
-server: cloudflare
-```
-
-#### よくある原因
-
-- cloudflared の origin が `nginx-gateway` ではなく古い `ingress-nginx` を指している
-- origin の TLS 検証に失敗（staging 証明書のまま）
-
-#### 診断と解決
-
-```bash
-# cloudflared のエラー確認
-kubectl logs -n cloudflared deploy/cloudflared --since=10m
-
-# origin の Service 指定を確認（例）
-# https://nginx-gateway-nginx.nginx-gateway.svc.cluster.local:443
-
-# ワイルドカード証明書が本番Issuerか確認
-kubectl get secret -n nginx-gateway wildcard-external-tls -o jsonpath='{.data.tls\.crt}' | \
-  base64 -d | openssl x509 -noout -issuer
-```
-
-## External Secrets 問題
-
-### 1. Secret が作成されない
-
-#### 症状
-```
-ExternalSecret status: SecretSyncedError
-```
-
-#### 診断と解決
-
-```bash
-# ClusterSecretStore状態
+kubectl get clustersecretstore
 kubectl describe clustersecretstore pulumi-esc-store
 
-# ExternalSecret詳細
+kubectl get externalsecrets -A
 kubectl describe externalsecret <name> -n <namespace>
 
-# Pulumi token確認
-kubectl get secret pulumi-access-token -n external-secrets -o yaml
-
-# 手動同期トリガー
+# 再同期トリガー
 kubectl annotate externalsecret <name> -n <namespace> \
   force-sync="$(date +%s)" --overwrite
 ```
 
-## GitHub Actions Runner 問題
+`SecretSyncedError` の主因:
 
-### 1. Runner が起動しない
+- Pulumi ESC 側キー名不一致
+- `remoteRef.key` の誤り
+- トークン期限切れ
+
+### 6. Harbor へ push できない
 
 ```bash
-# Runner Pod確認
-kubectl get pods -n arc-systems
+# ログイン（内部FQDN）
+docker login harbor.internal.qroksera.com
 
-# Runner ScaleSet確認
-helm list -n arc-systems
-helm get values <runner-name> -n arc-systems
-
-# Controller ログ
-kubectl logs -n arc-systems deployment/arc-gha-runner-scale-set-controller
-
-# ServiceAccount確認
-kubectl get serviceaccount github-actions-runner -n arc-systems
+# Harbor 側の状態
+kubectl get pods -n harbor
+kubectl logs -n harbor deployment/harbor-core
 ```
 
-### 2. ジョブが Queued のまま
+確認ポイント:
+
+- 端末に内部 CA を信頼登録できているか
+- namespace 側の pull secret が最新か
+
+### 7. 外部公開が 502 / 接続不可（Cloudflared + Gateway）
 
 ```bash
-# Runner設定確認
-helm get values <runner-name> -n arc-systems | grep -E "minRunners|maxRunners"
+kubectl get pods -n cloudflared
+kubectl logs -n cloudflared deploy/cloudflared --since=10m
 
-# minRunners を1以上に設定
-helm upgrade <runner-name> \
-  oci://ghcr.io/actions/actions-runner-controller-charts/gha-runner-scale-set \
-  --namespace arc-systems \
-  --set minRunners=1 \
-  --wait
-```
-
-## ネットワーク問題
-
-### 1. LoadBalancer IP が割り当てられない
-
-```bash
-# MetalLB確認
-kubectl get pods -n metallb-system
-kubectl logs -n metallb-system deployment/controller
-
-# IPプール確認
-kubectl get ipaddresspool -n metallb-system
-kubectl get l2advertisement -n metallb-system
-
-# Service再作成
-kubectl delete svc <service-name> -n <namespace>
-kubectl apply -f service.yaml
-```
-
-### 2. Gateway が機能しない
-
-```bash
-# NGINX Gateway Fabric確認
-kubectl get pods -n nginx-gateway
-kubectl logs -n nginx-gateway deployment/ngf-nginx-gateway-fabric
-kubectl logs -n nginx-gateway deployment/nginx-gateway-nginx
-
-# Gateway/HTTPRoute確認
 kubectl get gateway -A
-kubectl describe gateway <name> -n <namespace>
 kubectl get httproute -A
-kubectl describe httproute <name> -n <namespace>
+kubectl describe httproute <route-name> -n <namespace>
 
-# 証明書確認
 kubectl get certificate -A
 kubectl describe certificate <name> -n <namespace>
 ```
 
-## ストレージ問題
+確認ポイント:
 
-### 1. PVC が Pending
+- Cloudflared origin が `nginx-gateway-nginx.nginx-gateway.svc.cluster.local:443` を指しているか
+- `originServerName` が公開ホスト名と一致しているか
+- `wildcard-external-tls` が Ready か
+
+### 8. LoadBalancer IP が割り当てられない
 
 ```bash
-# StorageClass確認
+kubectl get svc -A | grep LoadBalancer
+kubectl get ipaddresspool -n metallb-system
+kubectl get l2advertisement -n metallb-system
+kubectl logs -n metallb-system deployment/controller
+```
+
+### 9. Runner がジョブを拾わない（ARC）
+
+```bash
+kubectl get pods -n arc-systems
+helm list -n arc-systems
+helm get values <runner-name> -n arc-systems
+```
+
+確認ポイント:
+
+- `minRunners` が 1 以上か
+- GitHub 側 repository/organization の Runner 権限が正しいか
+
+### 10. PVC が `Pending`
+
+```bash
+kubectl get pvc -A
+kubectl describe pvc <pvc-name> -n <namespace>
 kubectl get storageclass
 kubectl describe storageclass local-path
-
-# PVC詳細
-kubectl describe pvc <name> -n <namespace>
-
-# Provisioner Pod確認
 kubectl get pods -n local-path-storage
-kubectl logs -n local-path-storage deployment/local-path-provisioner
 ```
 
-### 2. ディスク容量不足
+## ログ収集テンプレート
 
 ```bash
-# ノードの容量確認
-ssh k8suser@192.168.122.10 'df -h'
-ssh k8suser@192.168.122.11 'df -h'
-ssh k8suser@192.168.122.12 'df -h'
-
-# 不要なイメージ削除
-ssh k8suser@192.168.122.10 'sudo crictl rmi --prune'
-
-# 古いログ削除
-ssh k8suser@192.168.122.10 'sudo journalctl --vacuum-time=7d'
-```
-
-## パフォーマンス問題
-
-### 1. クラスター全体が遅い
-
-```bash
-# リソース使用状況
-kubectl top nodes
-kubectl top pods -A --sort-by=cpu
-kubectl top pods -A --sort-by=memory
-
-# メトリクスサーバー確認
-kubectl get deployment metrics-server -n kube-system
-
-# etcd パフォーマンス
-ssh k8suser@192.168.122.10
-sudo ETCDCTL_API=3 etcdctl \
-  --endpoints=https://127.0.0.1:2379 \
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-  --cert=/etc/kubernetes/pki/etcd/server.crt \
-  --key=/etc/kubernetes/pki/etcd/server.key \
-  endpoint health
-```
-
-### 2. 特定のPodが遅い
-
-```bash
-# Pod リソース確認
-kubectl describe pod <pod-name> -n <namespace> | grep -A 10 resources
-
-# リミット調整
-kubectl set resources deployment <name> -n <namespace> \
-  --limits=cpu=1000m,memory=1Gi \
-  --requests=cpu=100m,memory=128Mi
-```
-
-## 完全リセット手順
-
-すべての問題解決策が失敗した場合：
-
-```bash
-# 1. VM削除確認
-sudo virsh list --all
-sudo virsh destroy <vm-name>
-sudo virsh undefine <vm-name>
-
-# 2. ネットワーククリーンアップ
-sudo virsh net-destroy default
-sudo virsh net-start default
-
-# 3. Terraformステートクリーン
-cd automation/infrastructure
-rm -rf .terraform terraform.tfstate*
-
-# 4. 再構築
-cd ~/k8s_myHome
-make all
-```
-
-## ログ収集スクリプト
-
-問題報告用のログ収集：
-
-```bash
-#!/bin/bash
-# collect-logs.sh
+#!/usr/bin/env bash
+set -euo pipefail
 
 LOG_DIR="k8s-debug-$(date +%Y%m%d-%H%M%S)"
-mkdir -p $LOG_DIR
+mkdir -p "$LOG_DIR"
 
-# システム情報
-make phase5 > $LOG_DIR/verify.txt 2>&1
+make phase5 > "$LOG_DIR/phase5.txt" 2>&1 || true
+kubectl get nodes -o wide > "$LOG_DIR/nodes.txt"
+kubectl get applications -n argocd > "$LOG_DIR/applications.txt"
+kubectl get pods -A > "$LOG_DIR/pods.txt"
+kubectl get events -A --sort-by='.lastTimestamp' > "$LOG_DIR/events.txt"
+cp automation/run.log "$LOG_DIR/run.log" 2>/dev/null || true
 
-# ノード情報
-kubectl get nodes -o wide > $LOG_DIR/nodes.txt
-kubectl describe nodes > $LOG_DIR/nodes-describe.txt
-
-# Pod情報
-kubectl get pods -A > $LOG_DIR/pods.txt
-kubectl get pods -A | grep -v Running > $LOG_DIR/problem-pods.txt
-
-# イベント
-kubectl get events -A > $LOG_DIR/events.txt
-
-# ArgoCD
-kubectl get applications -n argocd > $LOG_DIR/argocd-apps.txt
-
-# ログ
-cp automation/run.log $LOG_DIR/ 2>/dev/null
-
-# アーカイブ作成
-tar czf $LOG_DIR.tar.gz $LOG_DIR/
+tar czf "$LOG_DIR.tar.gz" "$LOG_DIR"
 echo "ログ収集完了: $LOG_DIR.tar.gz"
 ```
 
-## サポート
+## それでも解決しない場合
 
-解決しない場合は、収集したログと共に[GitHub Issues](https://github.com/ksera524/k8s_myHome/issues)で報告してください。
+1. `automation/run.log` と上記ログ収集アーカイブを保存
+2. 再現手順（いつ、何を実行したか）を時系列で整理
+3. [GitHub Issues](https://github.com/ksera524/k8s_myHome/issues) に報告

--- a/manifests/README.md
+++ b/manifests/README.md
@@ -7,7 +7,6 @@
 ```
 manifests/
 ├── bootstrap/                    # ArgoCD App-of-Apps
-├── config/                       # 非Secretの外部連携設定
 ├── core/                         # 基本リソース（namespace, storage-class など）
 ├── infrastructure/               # インフラ構成（networking, security など）
 ├── platform/                     # プラットフォームサービス（ArgoCD, ESO, ARC）


### PR DESCRIPTION
## Summary
- 実態とずれていた主要ドキュメントを、`manifests/` と App-of-Apps 定義に合わせて更新
- `applications.md` と `troubleshooting.md` を現行運用ベースに再構成し、旧前提（未使用構成/古い運用）を削除
- Sync Wave 図・manifest 配置ルール・README 導線を統一し、参照整合性を改善

## Scope
- docs/README.md
- docs/applications.md
- docs/diagrams/app-of-apps-sync-wave.md
- docs/gitops-design.md
- docs/kubernetes-architecture.md
- docs/manifest-layout.md
- docs/operations-guide.md
- docs/troubleshooting.md
- manifests/README.md

## What Changed (Highlights)
- `docs/applications.md`: 現在稼働中アプリ一覧へ更新、未使用の PostgreSQL 前提記述を削除
- `docs/troubleshooting.md`: 旧構成依存の手順を整理し、Phase5/run.log 起点の切り分けに統一
- `docs/gitops-design.md` / `docs/diagrams/app-of-apps-sync-wave.md`: Sync Wave とアプリ定義を現行構成へ同期
- `docs/manifest-layout.md` / `manifests/README.md`: `config/` 前提を削除し現行ディレクトリに整合

## Validation
- ドキュメント内の `manifests/...` 参照パス整合をローカルで確認
- 本PRはドキュメントのみの変更で、マニフェスト・スクリプトの実行ロジック変更なし

## Review Points
- 運用手順として残すべき記述の過不足（特に `applications.md` と `troubleshooting.md`）
- `app-of-apps` の説明粒度（詳細化/簡略化の希望）