### PR TITLE
chore: minimize ARC runner RBAC and allow controller chart repo

### DIFF
--- a/docs/gitops-design.md
+++ b/docs/gitops-design.md
@@ -84,6 +84,7 @@ manifests/
 例外:
 - GitHub Actions Runner は `add-runner.sh` による作成運用（GitOps 管理外）
 - ARC Controller は GitOps 管理対象（`manifests/platform/ci-cd/github-actions/arc-controller.yaml`）
+- ARC Runner ServiceAccount のRBACは GitOps 管理し、Secretアクセスは `harbor-auth` と `ca-key-pair` のみに限定
 
 ## ArgoCD AppProject（権限境界）
 

--- a/docs/operations-guide.md
+++ b/docs/operations-guide.md
@@ -149,6 +149,21 @@ RunnerはGitOps管理ではなく、`add-runner.sh` による作成運用とし�
 内部CAは `add-runner.sh` で Runner(dind) に自動配布されます。
 ARC ControllerはGitOps管理（`manifests/platform/ci-cd/github-actions/arc-controller.yaml`）を正とし、手動Helm適用は行いません。
 `manifests/platform/ci-cd/github-actions/` には controller と RBAC を保持します。
+Runner ServiceAccount（`arc-systems/github-actions-runner`）の権限は最小化し、実行時に必要なSecretのみ許可します。
+- `arc-systems/harbor-auth`（Harbor push用資格情報）
+- `cert-manager/ca-key-pair`（内部CA証明書）
+
+```bash
+# 権限確認（許可されること）
+kubectl auth can-i get secret/harbor-auth -n arc-systems \
+  --as=system:serviceaccount:arc-systems:github-actions-runner
+kubectl auth can-i get secret/ca-key-pair -n cert-manager \
+  --as=system:serviceaccount:arc-systems:github-actions-runner
+
+# 権限確認（拒否されること）
+kubectl auth can-i list secrets --all-namespaces \
+  --as=system:serviceaccount:arc-systems:github-actions-runner
+```
 
 #### Runner追加・削除
 

--- a/manifests/platform/argocd-config/argocd-projects.yaml
+++ b/manifests/platform/argocd-config/argocd-projects.yaml
@@ -59,6 +59,8 @@ spec:
     - https://argoproj.github.io/argo-helm
     - https://helm.goharbor.io
     - https://grafana.github.io/helm-charts
+    - ghcr.io/actions/actions-runner-controller-charts
+    - oci://ghcr.io/actions/actions-runner-controller-charts
   destinations:
     - server: https://kubernetes.default.svc
       namespace: argocd

--- a/manifests/platform/ci-cd/github-actions/github-actions-harbor-rbac.yaml
+++ b/manifests/platform/ci-cd/github-actions/github-actions-harbor-rbac.yaml
@@ -7,7 +7,7 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   resourceNames: ["harbor-tls-secret"]
-  verbs: ["get", "list"]
+  verbs: ["get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -34,7 +34,7 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   resourceNames: ["ca-key-pair"]
-  verbs: ["get", "list"]
+  verbs: ["get"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/platform/ci-cd/github-actions/github-actions-rbac.yaml
+++ b/manifests/platform/ci-cd/github-actions/github-actions-rbac.yaml
@@ -1,21 +1,24 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: github-actions-secret-reader
+  namespace: arc-systems
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "list"]
+  resourceNames: ["harbor-auth"]
+  verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: github-actions-secret-reader
+  namespace: arc-systems
 subjects:
 - kind: ServiceAccount
   name: github-actions-runner
   namespace: arc-systems
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: github-actions-secret-reader
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary
- ARC Runner ServiceAccount のSecret参照権限を最小化し、`harbor-auth` と `ca-key-pair` の `get` に限定しました。
- `setup-arc.sh` から過剰権限付与を削除し、旧運用で残る広権限RoleBinding/ClusterRoleBindingのクリーンアップを追加しました。
- `platform` AppProject に ARC Controller chart のrepo許可を追加し、`arc-controller` の `InvalidSpecError`（repo not permitted）解消を反映しました。

## Validation
- `kustomize build manifests/platform`
- `shellcheck -S error -x automation/scripts/github-actions/setup-arc.sh`
- `make phase4`
- `bash automation/scripts/github-actions/setup-arc.sh`