### PR TITLE
feat: stage ArgoCD core Helm application for gradual migration

### DIFF
--- a/automation/scripts/app-deploy.sh
+++ b/automation/scripts/app-deploy.sh
@@ -34,14 +34,13 @@ if ! "${ssh_cmd[@]}" 'kubectl get namespace argocd' >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! "${ssh_cmd[@]}" "test -f ${APP_OF_APPS_DST}" >/dev/null 2>&1; then
-  if [ ! -f "$APP_OF_APPS_SRC" ]; then
-    log_error "app-of-apps.yamlが見つかりません: $APP_OF_APPS_SRC"
-    exit 1
-  fi
-  log_status "App-of-Appsマニフェストを転送中..."
-  scp -o StrictHostKeyChecking=no "$APP_OF_APPS_SRC" "${K8S_USER}@${CONTROL_PLANE_IP}:${APP_OF_APPS_DST}"
+if [ ! -f "$APP_OF_APPS_SRC" ]; then
+  log_error "app-of-apps.yamlが見つかりません: $APP_OF_APPS_SRC"
+  exit 1
 fi
+
+log_status "App-of-Appsマニフェストを転送中..."
+scp -o StrictHostKeyChecking=no "$APP_OF_APPS_SRC" "${K8S_USER}@${CONTROL_PLANE_IP}:${APP_OF_APPS_DST}"
 
 log_status "App-of-Appsを適用中..."
 if "${ssh_cmd[@]}" "kubectl apply -f ${APP_OF_APPS_DST}"; then

--- a/docs/diagrams/app-of-apps-sync-wave.md
+++ b/docs/diagrams/app-of-apps-sync-wave.md
@@ -11,6 +11,7 @@ flowchart TD
 
   argocdProjects["ArgoCD Projects\nwave 0"]:::wave0
 
+  argocdCore["ArgoCD Core (Helm)\nwave 1"]:::wave1
   lp["Local Path Provisioner\nwave 1"]:::wave1
   core["Core (Namespaces/Storage/RBAC)\nwave 2"]:::wave2
   coredns["CoreDNS Config\nwave 2"]:::wave2
@@ -35,6 +36,7 @@ flowchart TD
   harborPatch["Harbor Patch\nwave 13"]:::wave13
 
   root --> argocdProjects
+  root --> argocdCore
   root --> lp
   root --> core
   root --> coredns
@@ -58,6 +60,7 @@ flowchart TD
   root --> harborPatch
 
   argocdProjects --> lp
+  argocdProjects --> argocdCore
   argocdProjects --> core
 
   core --> metallb
@@ -127,6 +130,7 @@ flowchart TD
 | Wave | コンポーネント | 意味/依存関係 |
 |------|----------------|--------------|
 | 0 | ArgoCD Projects | AppProjectを先に作成 |
+| 1 | ArgoCD Core (Helm) | ArgoCD本体のHelm移行を段階的に適用（手動同期） |
 | 1 | Local Path Provisioner | 永続ボリューム基盤を先に準備 |
 | 2 | Core / CoreDNS | 基本リソースとストレージ設定の土台 |
 | 3 | MetalLB | LoadBalancer を提供 |

--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -37,6 +37,31 @@ spec:
         factor: 2
         maxDuration: 3m
 
+# ArgoCD Core - ArgoCD本体をHelm chartで段階移行（手動同期）
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-core
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/ksera524/k8s_myHome.git
+    targetRevision: HEAD
+    path: manifests/platform/argocd-core
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+
 # Local Path Provisioner - Harborより先にデプロイが必要
 ---
 apiVersion: argoproj.io/v1alpha1

--- a/manifests/platform/argocd-core/argocd-core-app.yaml
+++ b/manifests/platform/argocd-core/argocd-core-app.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-core
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://argoproj.github.io/argo-helm
+    chart: argo-cd
+    targetRevision: 9.4.2
+    helm:
+      releaseName: argocd
+      values: |
+        configs:
+          cm:
+            create: false
+          rbac:
+            create: false
+          secret:
+            createSecret: false
+          params:
+            create: false
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/manifests/platform/argocd-core/kustomization.yaml
+++ b/manifests/platform/argocd-core/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - argocd-core-app.yaml


### PR DESCRIPTION
## Summary
- ArgoCD本体のHelm移行に向けて、`argocd-core` Application を追加しました（初期は手動同期運用）。
- `manifests/platform/argocd-core/` を新設し、`argo-cd` chart `9.4.2`（appVersion `v3.3.0` 整合）を `releaseName: argocd` で定義しました。
- `app-of-apps` に `argocd-core`（wave 1）を追加し、Sync Wave 図も更新しました。
- `app-deploy.sh` を更新し、`app-of-apps.yaml` を毎回転送するようにして、変更反映漏れを防止しました。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml manifests/platform/argocd-core/argocd-core-app.yaml manifests/platform/argocd-core/kustomization.yaml`
- `shellcheck -S error -x automation/scripts/app-deploy.sh`
- `kustomize build manifests/platform/argocd-core`
- `make phase4`