### PR TITLE
fix: stabilize argocd-core cutover sync behavior

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -115,6 +115,27 @@ kubectl rollout restart deployment argocd-applicationset-controller -n argocd
 kubectl rollout status deployment argocd-applicationset-controller -n argocd --timeout=180s
 ```
 
+`argocd-core` の手動同期で `spec.selector is immutable` が出る場合:
+
+```bash
+kubectl patch application argocd-core -n argocd --type=merge -p '{
+  "operation": {
+    "sync": {
+      "prune": false,
+      "syncOptions": [
+        "ServerSideApply=true",
+        "Replace=true",
+        "Force=true",
+        "DisableClientSideApplyMigration=true"
+      ]
+    }
+  }
+}'
+```
+
+補足:
+- `argocd-core` は `redisSecretInit.enabled=false` で運用し、hookリソース競合を回避する
+
 ### 5. ExternalSecret が同期されない
 
 ```bash

--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -66,6 +66,8 @@ spec:
             createSecret: false
           params:
             create: false
+        redisSecretInit:
+          enabled: false
   destination:
     server: https://kubernetes.default.svc
     namespace: argocd


### PR DESCRIPTION
## Summary
- `argocd-core` の Helm values に `redisSecretInit.enabled=false` を追加し、手動同期時の hook リソース競合（Role/RoleBinding already exists）を回避しました。
- `docs/troubleshooting.md` に、`argocd-core` の手動同期で `spec.selector is immutable` が発生した場合の復旧手順（Force/Replace + SSA）を追記しました。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml`
- `make phase4`
- `make phase5`
- 手動 cutover 実施後、`argocd-core` が `Synced/Healthy` を確認