### PR TITLE
fix: remove duplicated resources from platform app

### DIFF
--- a/manifests/platform/kustomization.yaml
+++ b/manifests/platform/kustomization.yaml
@@ -4,5 +4,3 @@ kind: Kustomization
 resources:
   - ci-cd/github-actions/
   - argocd-config/
-  - secrets/external-secrets/
-  - argocd-image-updater/


### PR DESCRIPTION
## Summary
- `manifests/platform/kustomization.yaml` から `secrets/external-secrets/` と `argocd-image-updater/` を除外し、`platform` Application の二重管理を解消しました。
- `config-secrets` / `argocd-image-updater` の専用 Application と責務を分離し、SharedResourceWarning と OutOfSync の原因を除去します。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/platform/kustomization.yaml`
- `kustomize build manifests/platform`
- `make phase4` 実行で、`config-secrets` と `argocd-image-updater` が `Synced/Healthy` になることを確認

## Notes
- `platform` は現在 remote main 参照のため、PRマージまではクラスタ上で OutOfSync が残ります。
- マージ後に `make phase4` / `make phase5` を再実行すれば反映されます。