### PR TITLE
fix: reduce remaining argocd sync drift

### DIFF
--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -682,6 +682,15 @@ spec:
         duration: 5s
         factor: 2
         maxDuration: 3m
+  ignoreDifferences:
+    - group: external-secrets.io
+      kind: ExternalSecret
+      jqPathExpressions:
+        - ".spec.data[].remoteRef.conversionStrategy"
+        - ".spec.data[].remoteRef.decodingStrategy"
+        - ".spec.data[].remoteRef.metadataPolicy"
+        - ".spec.target.deletionPolicy"
+        - ".spec.target.mergePolicy"
 ---
 # ArgoCD Image Updater - イメージ更新自動化（ArgoCD書き戻し）
 apiVersion: argoproj.io/v1alpha1

--- a/manifests/bootstrap/applications/user-apps/cooklog-app.yaml
+++ b/manifests/bootstrap/applications/user-apps/cooklog-app.yaml
@@ -11,7 +11,6 @@ spec:
     repoURL: https://github.com/ksera524/k8s_myHome.git
     targetRevision: main
     path: manifests/apps/cooklog
-    kustomize: {}
   destination:
     server: https://kubernetes.default.svc
     namespace: sandbox


### PR DESCRIPTION
## Summary
- `platform` Application に ExternalSecret の defaulting 差分を無視する `ignoreDifferences` を追加し、`harbor-registry` 系の恒常的な OutOfSync を抑制しました。
- `user-application-definitions` 配下の `cooklog` 定義から空の `source.kustomize` を削除し、Application 定義の差分ドリフトを解消しました。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml manifests/bootstrap/applications/user-apps/cooklog-app.yaml`
- `make phase4`
- `make phase5`

## Current Status
- `argocd-core`, `platform`, `config-secrets`, `argocd-image-updater` は `Synced/Healthy`
- 残件は `user-application-definitions` のみ（このPRマージ後に解消見込み）