### PR TITLE
chore: bump tailscale operator and ARC controller patch versions

### DIFF
--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -592,7 +592,7 @@ spec:
   project: infrastructure
   source:
     repoURL: https://pkgs.tailscale.com/helmcharts
-    targetRevision: 1.94.1
+    targetRevision: 1.94.2
     chart: tailscale-operator
     helm:
       values: |

--- a/manifests/platform/ci-cd/github-actions/arc-controller.yaml
+++ b/manifests/platform/ci-cd/github-actions/arc-controller.yaml
@@ -11,7 +11,7 @@ spec:
   project: platform
   source:
     repoURL: ghcr.io/actions/actions-runner-controller-charts
-    targetRevision: 0.13.0
+    targetRevision: 0.13.1
     chart: gha-runner-scale-set-controller
     helm:
       values: |


### PR DESCRIPTION
## Summary
- `tailscale-operator` を `1.94.1` から `1.94.2` に更新しました（`manifests/bootstrap/app-of-apps.yaml`）。
- ARC Controller chart を `0.13.0` から `0.13.1` に更新しました（`manifests/platform/ci-cd/github-actions/arc-controller.yaml`）。
- いずれも週次監査 Issue #80 の小差分（patch）対象を優先して適用しています。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml manifests/platform/ci-cd/github-actions/arc-controller.yaml`
- `kustomize build manifests/platform`
- `make phase4`
- `make phase5`

## Notes
- `phase5` 時点で `user-application-definitions` が `OutOfSync/Healthy` になる既知傾向は継続しています（今回変更とは独立）。
- `tailscale` namespace のPodは更新後に `Running` を確認済みです。