### PR TITLE
chore: bump harbor and rustfs patch versions

### DIFF
--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -760,7 +760,7 @@ spec:
   project: platform
   source:
     repoURL: 'https://helm.goharbor.io'
-    targetRevision: 1.18.0
+    targetRevision: 1.18.2
     chart: harbor
     helm:
       values: |

--- a/manifests/bootstrap/applications/user-apps/rustfs-app.yaml
+++ b/manifests/bootstrap/applications/user-apps/rustfs-app.yaml
@@ -9,7 +9,7 @@ spec:
   project: apps
   source:
     repoURL: https://charts.rustfs.com
-    targetRevision: 0.0.81
+    targetRevision: 0.0.83
     chart: rustfs
     helm:
       values: |


### PR DESCRIPTION
## Summary
- Harbor chart を `1.18.0` から `1.18.2` に更新しました（`manifests/bootstrap/app-of-apps.yaml`）。
- RustFS chart を `0.0.81` から `0.0.83` に更新しました（`manifests/bootstrap/applications/user-apps/rustfs-app.yaml`）。
- 週次監査 Issue #80 のうち、差分が小さい patch 更新を優先適用しています。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml manifests/bootstrap/applications/user-apps/rustfs-app.yaml`
- `make phase4`
- `make phase5`

## Notes
- Harbor は chart pull の一時的なネットワークエラーで `Unknown` を一度観測しましたが、hard refresh 後に `Synced/Healthy` へ収束を確認済みです。
- `user-application-definitions` の `OutOfSync/Healthy` は既存の断続事象として継続（今回変更とは独立）。