### PR TITLE
chore: bump k8s-monitoring chart minor version

### DIFF
--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -888,7 +888,7 @@ spec:
   sources:
     - repoURL: https://grafana.github.io/helm-charts
       chart: k8s-monitoring
-      targetRevision: 3.7.4
+      targetRevision: 3.8.0
       helm:
         valueFiles:
           - $values/manifests/monitoring/grafana-k8s-monitoring-values.yaml


### PR DESCRIPTION
## Summary
- `monitoring` Application の Helm chart `k8s-monitoring` を `3.7.4` から `3.8.0` に更新しました。
- 週次監査 Issue #80 の差分が小さい順（patch群の次）で minor 更新を反映しています。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml`
- `make phase4`
- `make phase5`

## Notes
- `monitoring` は手動同期後 `Synced/Healthy` を確認済みです。
- `user-application-definitions` の `OutOfSync/Healthy` は既知の断続事象（slack Application が対象）で、今回変更とは独立です。