### PR TITLE
chore: bump local-path-provisioner image version

### DIFF
--- a/manifests/infrastructure/storage/local-path/local-path-provisioner.yaml
+++ b/manifests/infrastructure/storage/local-path/local-path-provisioner.yaml
@@ -62,7 +62,7 @@ spec:
       serviceAccountName: local-path-provisioner-service-account
       containers:
         - name: local-path-provisioner
-          image: rancher/local-path-provisioner:v0.0.24
+          image: rancher/local-path-provisioner:v0.0.34
           imagePullPolicy: IfNotPresent
           command:
             - local-path-provisioner


### PR DESCRIPTION
## Summary
- `local-path-provisioner` のイメージを `v0.0.24` から `v0.0.34` に更新しました。
- 週次監査 Issue #80 のうち、手動更新対象（container image）の小さめ差分を順番に反映しています。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/infrastructure/storage/local-path/local-path-provisioner.yaml`
- `kustomize build manifests/infrastructure/storage/local-path`
- `make phase4`
- `make phase5`

## Notes
- 更新後 `local-path-provisioner` Application は `Synced/Healthy` を確認済みです。
- `user-application-definitions` の `OutOfSync/Healthy` は既存の断続事象として継続（今回変更とは独立）。