### PR TITLE
chore: bump metallb chart version

### DIFF
--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -192,7 +192,7 @@ spec:
   project: infrastructure
   source:
     repoURL: 'https://metallb.github.io/metallb'
-    targetRevision: v0.13.12
+    targetRevision: 0.15.3
     chart: metallb
     helm:
       skipCrds: true


### PR DESCRIPTION
## Summary
- MetalLB chart を `v0.13.12` から `0.15.3` に更新しました（`manifests/bootstrap/app-of-apps.yaml`）。
- 週次監査 Issue #80 の残件を、影響確認しながら順に更新しています。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml`
- `make phase4`
- `make phase5`

## Runtime Check
- `metallb-system` の controller/speaker Pod がすべて `Running`
- ArgoCD `metallb` Application が `Synced/Healthy` に収束

## Notes
- `user-application-definitions` の `OutOfSync/Healthy` は既知の断続事象として継続（今回変更とは独立）