### PR TITLE
chore: bump cert-manager chart version

### DIFF
--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -378,7 +378,7 @@ spec:
   project: infrastructure
   source:
     repoURL: 'https://charts.jetstack.io'
-    targetRevision: v1.13.3
+    targetRevision: v1.19.3
     chart: cert-manager
     helm:
       values: |


### PR DESCRIPTION
## Summary
- cert-manager chart を `v1.13.3` から `v1.19.3` に更新しました（`manifests/bootstrap/app-of-apps.yaml`）。
- 週次監査 Issue #80 の残件を順次更新する流れで反映しています。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml`
- `make phase4`
- `make phase5`

## Runtime Check
- `cert-manager` namespace の `cert-manager/cainjector/webhook` Pod が `Running`
- ArgoCD `cert-manager` Application が `Synced/Healthy` に収束

## Notes
- `user-application-definitions` の `OutOfSync/Healthy` は既知の断続事象（今回変更とは独立）