### PR TITLE
chore: bump external-secrets chart major version

### DIFF
--- a/manifests/bootstrap/app-of-apps.yaml
+++ b/manifests/bootstrap/app-of-apps.yaml
@@ -500,7 +500,7 @@ spec:
   project: platform
   source:
     repoURL: 'https://charts.external-secrets.io'
-    targetRevision: '0.18.2'
+    targetRevision: '2.0.0'
     chart: external-secrets
     helm:
       values: |


### PR DESCRIPTION
## Summary
- External Secrets Operator chart を `0.18.2` から `2.0.0` に更新しました（`manifests/bootstrap/app-of-apps.yaml`）。
- 週次監査 Issue #80 の残件（major）を段階確認しながら反映しています。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/app-of-apps.yaml`
- `make phase4`
- `make phase5`

## Runtime Check
- `external-secrets-system` の `external-secrets-operator` Pod が `Running`
- ArgoCD `external-secrets-operator` Application が `Synced/Healthy` に収束

## Notes
- `user-application-definitions` の `OutOfSync/Healthy` は既知の断続事象（今回変更とは独立）