### PR TITLE
fix: remove redundant slack kustomize block to avoid drift

### DIFF
--- a/manifests/bootstrap/applications/user-apps/slack-app.yaml
+++ b/manifests/bootstrap/applications/user-apps/slack-app.yaml
@@ -20,7 +20,6 @@ spec:
     repoURL: https://github.com/ksera524/k8s_myHome.git
     targetRevision: HEAD
     path: manifests/apps/slack
-    kustomize: {}
   destination:
     server: https://kubernetes.default.svc
     namespace: sandbox


### PR DESCRIPTION
## Summary
- `user-application-definitions` の `OutOfSync/Healthy` の原因だった `slack` Application 定義の `source.kustomize: {}` を削除しました。
- live リソース側では空の `kustomize` ブロックが保持されず差分化していたため、宣言側を実態に合わせてドリフトを解消します。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/bootstrap/applications/user-apps/slack-app.yaml`
- `make phase4`
- `kubectl get applications -n argocd` で `user-application-definitions` 以外が `Synced/Healthy` であることを確認

## Notes
- ARC listener Pod の Pending/Terminating はローリング時の一時状態で、短時間で `Running` に収束することを確認しました。