### PR TITLE
chore: introduce single source for ARC chart version

### DIFF
--- a/manifests/platform/ci-cd/github-actions/arc-version-configmap.yaml
+++ b/manifests/platform/ci-cd/github-actions/arc-version-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: arc-version
+  namespace: argocd
+data:
+  controllerChartVersion: "0.13.1"

--- a/manifests/platform/ci-cd/github-actions/kustomization.yaml
+++ b/manifests/platform/ci-cd/github-actions/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  # ARC version single source of truth
+  - arc-version-configmap.yaml
   # ARC Controller (ArgoCD Application経由でHelm chartをデプロイ)
   - arc-controller.yaml
   # RBAC
@@ -10,3 +12,15 @@ resources:
   # External Secrets (GitHub PATはESO経由で取得)
   # Note: github-auth-secretはplatform/secrets/external-secrets/external-secret-resources.yamlで管理
   # Runner ScaleSetはadd-runner.shでsettings.tomlに基づいて作成
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: arc-version
+      fieldPath: data.controllerChartVersion
+    targets:
+      - select:
+          kind: Application
+          name: arc-controller
+        fieldPaths:
+          - spec.source.targetRevision


### PR DESCRIPTION
## Summary
- ARC chart version の単一ソースとして `arc-version` ConfigMap を追加しました。
- `kustomization.yaml` の `replacements` を使って、`arc-controller` Application の `spec.source.targetRevision` に version を注入するよう変更しました。
- これにより、今後の version 変更は `arc-version-configmap.yaml` の1箇所更新で反映できます。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/platform/ci-cd/github-actions/arc-version-configmap.yaml manifests/platform/ci-cd/github-actions/kustomization.yaml`
- `kustomize build manifests/platform`
- `make phase4`
- `make phase5`