### PR TITLE
feat: add ARC runner ApplicationSet pilot for blog

### DIFF
--- a/manifests/platform/ci-cd/github-actions/kustomization.yaml
+++ b/manifests/platform/ci-cd/github-actions/kustomization.yaml
@@ -6,6 +6,8 @@ resources:
   - arc-version-configmap.yaml
   # ARC Controller (ArgoCD Application経由でHelm chartをデプロイ)
   - arc-controller.yaml
+  # ARC RunnerScaleSet (ApplicationSetでGitOps管理)
+  - runners-appset.yaml
   # RBAC
   - github-actions-rbac.yaml
   - github-actions-harbor-rbac.yaml
@@ -24,3 +26,8 @@ replacements:
           name: arc-controller
         fieldPaths:
           - spec.source.targetRevision
+      - select:
+          kind: ApplicationSet
+          name: arc-runners
+        fieldPaths:
+          - spec.template.spec.source.targetRevision

--- a/manifests/platform/ci-cd/github-actions/runners-appset.yaml
+++ b/manifests/platform/ci-cd/github-actions/runners-appset.yaml
@@ -1,0 +1,128 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: arc-runners
+  namespace: argocd
+spec:
+  goTemplate: true
+  generators:
+    - list:
+        elements:
+          - name: blog
+            githubOwner: ksera524
+            githubRepo: blog
+            runnerName: blog-runners
+            minRunners: "1"
+            maxRunners: "3"
+  template:
+    metadata:
+      name: '{{ .name }}-runner'
+      namespace: argocd
+      annotations:
+        argocd.argoproj.io/sync-wave: "9"
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: platform
+      source:
+        repoURL: ghcr.io/actions/actions-runner-controller-charts
+        chart: gha-runner-scale-set
+        targetRevision: 0.13.1
+        helm:
+          releaseName: '{{ .runnerName }}'
+          parameters:
+            - name: githubConfigUrl
+              value: 'https://github.com/{{ .githubOwner }}/{{ .githubRepo }}'
+            - name: githubConfigSecret
+              value: github-multi-repo-secret
+            - name: minRunners
+              value: '{{ .minRunners }}'
+            - name: maxRunners
+              value: '{{ .maxRunners }}'
+            - name: controllerServiceAccount.namespace
+              value: arc-systems
+            - name: controllerServiceAccount.name
+              value: arc-controller-gha-rs-controller
+          values: |
+            template:
+              spec:
+                serviceAccountName: github-actions-runner
+                hostAliases:
+                  - ip: 192.168.122.100
+                    hostnames:
+                      - harbor.internal.qroksera.com
+                initContainers:
+                  - name: init-dind-externals
+                    image: ghcr.io/actions/actions-runner:latest
+                    command: ["cp"]
+                    args: ["-r", "/home/runner/externals/.", "/home/runner/tmpDir/"]
+                    volumeMounts:
+                      - name: dind-externals
+                        mountPath: /home/runner/tmpDir
+                  - name: dind
+                    image: docker:dind
+                    command: ["sh", "-c"]
+                    args:
+                      - |
+                        set -e
+                        cp /etc/docker/certs.d/harbor.internal.qroksera.com/ca.crt /usr/local/share/ca-certificates/harbor-internal-ca.crt
+                        update-ca-certificates
+                        dockerd --host=unix:///var/run/docker.sock --group=$(DOCKER_GROUP_GID) --insecure-registry=harbor.internal.qroksera.com
+                    env:
+                      - name: DOCKER_GROUP_GID
+                        value: "123"
+                    securityContext:
+                      privileged: true
+                    restartPolicy: Always
+                    startupProbe:
+                      exec:
+                        command: ["docker", "info"]
+                      failureThreshold: 24
+                      periodSeconds: 5
+                    volumeMounts:
+                      - name: work
+                        mountPath: /home/runner/_work
+                      - name: dind-sock
+                        mountPath: /var/run
+                      - name: dind-externals
+                        mountPath: /home/runner/externals
+                      - name: harbor-internal-ca
+                        mountPath: /etc/docker/certs.d/harbor.internal.qroksera.com
+                        readOnly: true
+                containers:
+                  - name: runner
+                    image: ghcr.io/actions/actions-runner:latest
+                    command: ["/home/runner/run.sh"]
+                    env:
+                      - name: DOCKER_HOST
+                        value: unix:///var/run/docker.sock
+                      - name: RUNNER_WAIT_FOR_DOCKER_IN_SECONDS
+                        value: "120"
+                    volumeMounts:
+                      - name: work
+                        mountPath: /home/runner/_work
+                      - name: dind-sock
+                        mountPath: /var/run
+                volumes:
+                  - name: dind-sock
+                    emptyDir: {}
+                  - name: dind-externals
+                    emptyDir: {}
+                  - name: work
+                    emptyDir: {}
+                  - name: harbor-internal-ca
+                    configMap:
+                      name: harbor-internal-ca
+                      items:
+                        - key: ca.crt
+                          path: ca.crt
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: arc-systems
+      syncPolicy:
+        automated:
+          prune: false
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true


### PR DESCRIPTION
## Summary
- ARC Runner を GitOps 管理へ移行する第一段として、`blog` リポジトリ向けの `ApplicationSet` パイロットを追加しました。
- `runners-appset.yaml` で `gha-runner-scale-set` を生成し、既存の dind/内部CA 設定・ServiceAccount・github secret 参照をテンプレ化しました。
- ARC version SSOT（`arc-version` ConfigMap）の `replacements` を拡張し、Controller と Runner chart version が同一値になるようにしました。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/platform/ci-cd/github-actions/runners-appset.yaml manifests/platform/ci-cd/github-actions/kustomization.yaml`
- `kustomize build manifests/platform`
- `make phase5`

## Runtime Check (pilot)
- `arc-runners` ApplicationSet を適用し、生成された `blog-runner` Application が `Synced/Healthy` を確認
- `blog-runners` の `AutoscalingRunnerSet` と listener/runner Pod が稼働することを確認