### PR TITLE
feat: expand ARC runner ApplicationSet to all repos

### DIFF
--- a/manifests/platform/ci-cd/github-actions/runners-appset.yaml
+++ b/manifests/platform/ci-cd/github-actions/runners-appset.yaml
@@ -14,6 +14,24 @@ spec:
             runnerName: blog-runners
             minRunners: "1"
             maxRunners: "3"
+          - name: cooklog
+            githubOwner: ksera524
+            githubRepo: cookLog
+            runnerName: cooklog-runners
+            minRunners: "1"
+            maxRunners: "3"
+          - name: hitomi
+            githubOwner: ksera524
+            githubRepo: hitomi
+            runnerName: hitomi-runners
+            minRunners: "1"
+            maxRunners: "3"
+          - name: slack-rs
+            githubOwner: ksera524
+            githubRepo: slack.rs
+            runnerName: slack-rs-runners
+            minRunners: "1"
+            maxRunners: "3"
   template:
     metadata:
       name: '{{ .name }}-runner'


### PR DESCRIPTION
## Summary
- ARC Runner ApplicationSet の対象を `blog` から全対象リポジトリへ拡張しました。
- 追加対象: `cooklog`, `hitomi`, `slack-rs`（`githubRepo`, `runnerName`, min/max runners を定義）。
- これにより Runner 作成の主経路を GitOps 側へ寄せ、Controller/Runner の version 一致運用を進めます。

## Validation
- `yamllint -f parsable -c .yamllint.yml manifests/platform/ci-cd/github-actions/runners-appset.yaml`
- `kustomize build manifests/platform`
- `make phase4`
- `make phase5`

## Notes
- 現行 main 追従クラスタでは `arc-runners` が `blog` のみ定義のため、追加3件はこのPRマージ後に生成されます。
- 収束確認はマージ後に `blog-runner/cooklog-runner/hitomi-runner/slack-rs-runner` の `Synced/Healthy` を確認予定です。